### PR TITLE
Update test.c

### DIFF
--- a/test.c
+++ b/test.c
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
             RGBA(0xff, 0, 0, 0xff),
             RGBA(0xff, 0, 0xff, 0x80)
     };
-    libattopng_set_palette(png, palette, 4);
+    libattopng_set_palette(png, palette, 16);
 
     for (y = 0; y < H; y++) {
         for (x = 0; x < W; x++) {


### PR DESCRIPTION
test_palette.png test case was written with the incorrect number of bytes provided to the libattopng_set_palette() call.  There are 4, 1 byte, numbers in each of 4 rows for the provided palette, giving a total of 16 bytes.

We can also look elsewhere in libattopng.c, to where there is a comment referencing a "minimum palette length" of 16, which means the 4 byte value in the test case doesn't even make sense.